### PR TITLE
HTBHF-2577 Modify the property value for UC Monthly Income Threshold …

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -27,7 +27,7 @@ eligibility-check-period-length: 28
 
 dwp:
   base-uri: ${DWP_API_URI:http://localhost:8110}
-  uc-monthly-income-threshold: 408.00
+  uc-monthly-income-threshold-in-pence: 40800
 
 hmrc:
   base-uri: ${HMRC_API_URI:http://localhost:8130}

--- a/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/service/v1/EligibilityServiceTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/service/v1/EligibilityServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.dhsc.htbhf.eligibility.model.v1.hmrc.HMRCEligibilityResponse;
 import uk.gov.dhsc.htbhf.eligibility.testhelper.v1.EligibilityResponseTestDataFactory;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.concurrent.ExecutionException;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -66,7 +67,8 @@ class EligibilityServiceTest {
         DWPEligibilityRequest sentRequest = argumentCaptor.getValue();
         assertThat(sentRequest.getPerson()).isEqualTo(person);
         // Below values match those in test/resources/application.yml
-        assertThat(sentRequest.getUcMonthlyIncomeThreshold()).isEqualTo(BigDecimal.valueOf(408.0));
+        BigDecimal expectedThresholdInPounds = BigDecimal.valueOf(408.00).setScale(2, RoundingMode.HALF_UP);
+        assertThat(sentRequest.getUcMonthlyIncomeThreshold()).isEqualTo(expectedThresholdInPounds);
         assertThat(sentRequest.getEligibleStartDate()).isEqualTo(sentRequest.getEligibleEndDate().minusWeeks(4));
         assertThat(sentRequest.getEligibleEndDate()).isNotNull();
     }

--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -6,7 +6,7 @@ eligibility-check-period-length: 28
 # set dwp and hmrc ports to be the same so they can be stubbed with single wiremock instances.
 dwp:
   base-uri: ${DWP_API_URI:http://localhost:8110}
-  uc-monthly-income-threshold: 408.00
+  uc-monthly-income-threshold-in-pence: 40800
 
 hmrc:
   base-uri: ${HMRC_API_URI:http://localhost:8110}


### PR DESCRIPTION
…so its in pence rather than pounds.

This is required for v2 which uses the value in pence, so modifying v1 to deal with a pence value first.