### PR TITLE
HTBHF-2676 Use CombinedIdentityAndEligibilityResponse as the response…

### DIFF
--- a/api/src/main/java/uk/gov/dhsc/htbhf/eligibility/controller/v2/EligibilityControllerV2.java
+++ b/api/src/main/java/uk/gov/dhsc/htbhf/eligibility/controller/v2/EligibilityControllerV2.java
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.dwp.model.v2.PersonDTOV2;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.eligibility.service.v2.IdentityAndEligibilityService;
 
 import javax.validation.Valid;
@@ -31,20 +31,20 @@ public class EligibilityControllerV2 {
      * Invokes downstream services to obtain a decision on the identity and eligibility for the given person.
      *
      * @param person the {@link PersonDTOV2}
-     * @return the {@link IdentityAndEligibilityResponse}
+     * @return the {@link CombinedIdentityAndEligibilityResponse}
      */
     @PostMapping(consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
     @ResponseBody
-    public IdentityAndEligibilityResponse getIdentityAndEligibilityDecision(@RequestBody @Valid PersonDTOV2 person) {
+    public CombinedIdentityAndEligibilityResponse getIdentityAndEligibilityDecision(@RequestBody @Valid PersonDTOV2 person) {
         log.debug("Received eligibility request V2");
 
-        IdentityAndEligibilityResponse response = identityAndEligibilityService.checkIdentityAndEligibility(person);
+        CombinedIdentityAndEligibilityResponse response = identityAndEligibilityService.checkIdentityAndEligibility(person);
 
         logResponse(response);
         return response;
     }
 
-    private void logResponse(IdentityAndEligibilityResponse response) {
+    private void logResponse(CombinedIdentityAndEligibilityResponse response) {
         log.debug("Returning identity status: {}, eligibility status: {}, qualifying benefits: {}, addressLine1: {}, postcode: {}, mobile: {}, email: {}",
                 response.getIdentityStatus(), response.getEligibilityStatus(), response.getQualifyingBenefits(),
                 response.getAddressLine1Match(), response.getPostcodeMatch(), response.getMobilePhoneMatch(), response.getEmailAddressMatch());

--- a/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/EligibilityServiceIntegrationTests.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/EligibilityServiceIntegrationTests.java
@@ -30,12 +30,12 @@ import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
+import static uk.gov.dhsc.htbhf.TestConstants.DWP_HOUSEHOLD_IDENTIFIER;
+import static uk.gov.dhsc.htbhf.TestConstants.HMRC_HOUSEHOLD_IDENTIFIER;
 import static uk.gov.dhsc.htbhf.assertions.IntegrationTestAssertions.assertInternalServerErrorResponse;
 import static uk.gov.dhsc.htbhf.assertions.IntegrationTestAssertions.assertValidationErrorInResponse;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.NO_MATCH;
-import static uk.gov.dhsc.htbhf.eligibility.testhelper.TestConstants.SIMPSON_DWP_HOUSEHOLD_IDENTIFIER;
-import static uk.gov.dhsc.htbhf.eligibility.testhelper.TestConstants.SIMPSON_HMRC_HOUSEHOLD_IDENTIFIER;
 import static uk.gov.dhsc.htbhf.eligibility.testhelper.v1.DWPEligibilityResponseTestDataFactory.aDWPEligibilityResponseWithStatus;
 import static uk.gov.dhsc.htbhf.eligibility.testhelper.v1.EligibilityResponseTestDataFactory.anEligibilityResponseWithDwpHouseholdIdentifier;
 import static uk.gov.dhsc.htbhf.eligibility.testhelper.v1.EligibilityResponseTestDataFactory.anEligibilityResponseWithHmrcHouseholdIdentifier;
@@ -89,7 +89,7 @@ class EligibilityServiceIntegrationTests {
     void shouldReturnEligibleResponseGivenEligibleResponseFromDwp(EligibilityStatus hmrcResponseEligibilityStatus) throws JsonProcessingException {
         runIntegrationTestReturningEligibilityResponse(ELIGIBLE,
                 hmrcResponseEligibilityStatus,
-                anEligibilityResponseWithDwpHouseholdIdentifier(ELIGIBLE, SIMPSON_DWP_HOUSEHOLD_IDENTIFIER));
+                anEligibilityResponseWithDwpHouseholdIdentifier(ELIGIBLE, DWP_HOUSEHOLD_IDENTIFIER));
     }
 
     @ParameterizedTest(name = "Should return {2} response from eligibility-service when DWP status returned is {0} and HMRC is {1}")
@@ -128,7 +128,7 @@ class EligibilityServiceIntegrationTests {
     void shouldReturnEligibleResponseGivenEligibleResponseFromHmrc(EligibilityStatus dwpResponseEligibilityStatus) throws JsonProcessingException {
         runIntegrationTestReturningEligibilityResponse(dwpResponseEligibilityStatus,
                 ELIGIBLE,
-                anEligibilityResponseWithHmrcHouseholdIdentifier(ELIGIBLE, SIMPSON_HMRC_HOUSEHOLD_IDENTIFIER));
+                anEligibilityResponseWithHmrcHouseholdIdentifier(ELIGIBLE, HMRC_HOUSEHOLD_IDENTIFIER));
     }
 
     @Test

--- a/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/EligibilityServiceIntegrationTestsV2.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/EligibilityServiceIntegrationTestsV2.java
@@ -17,6 +17,7 @@ import uk.gov.dhsc.htbhf.dwp.http.v2.HeaderName;
 import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.dwp.model.v2.PersonDTOV2;
 import uk.gov.dhsc.htbhf.dwp.testhelper.TestConstants;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.errorhandler.ErrorResponse;
 
 import java.net.URI;
@@ -30,9 +31,10 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.OK;
 import static uk.gov.dhsc.htbhf.assertions.IntegrationTestAssertions.assertInternalServerErrorResponse;
 import static uk.gov.dhsc.htbhf.assertions.IntegrationTestAssertions.assertValidationErrorInResponse;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches;
+import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anAllMatchedEligibilityConfirmedUCResponseWithHouseholdIdentifier;
 import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.PersonDTOV2TestDataFactory.aPersonDTOV2WithNino;
 import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.PersonDTOV2TestDataFactory.aValidPersonDTOV2;
+import static uk.gov.dhsc.htbhf.eligibility.testhelper.v2.CombinedIdAndEligibilityResponseTestDataFactory.anIdMatchedEligibilityConfirmedResponseWithNoHmrcHouseholdIdentifier;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -51,14 +53,15 @@ class EligibilityServiceIntegrationTestsV2 {
     void shouldReturnEligibleResponseGivenEligibleResponseReturnedFromDwp() throws JsonProcessingException {
         //Given
         PersonDTOV2 person = aValidPersonDTOV2();
-        IdentityAndEligibilityResponse identityAndEligibilityResponse = anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches();
+        IdentityAndEligibilityResponse identityAndEligibilityResponse = anAllMatchedEligibilityConfirmedUCResponseWithHouseholdIdentifier();
         stubDWPEndpointWithSuccessfulResponse(identityAndEligibilityResponse);
         //When
-        ResponseEntity<IdentityAndEligibilityResponse> responseEntity = restTemplate.exchange(buildRequestEntity(person), IdentityAndEligibilityResponse.class);
+        ResponseEntity<CombinedIdentityAndEligibilityResponse> responseEntity = restTemplate.exchange(buildRequestEntity(person),
+                CombinedIdentityAndEligibilityResponse.class);
         //Then
         assertThat(responseEntity.getStatusCode()).isEqualTo(OK);
         assertThat(responseEntity.hasBody()).isTrue();
-        assertThat(identityAndEligibilityResponse).isEqualTo(identityAndEligibilityResponse);
+        assertThat(responseEntity.getBody()).isEqualTo(anIdMatchedEligibilityConfirmedResponseWithNoHmrcHouseholdIdentifier());
         verifyDWPEndpointCalled();
     }
 

--- a/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/controller/v2/EligibilityControllerV2Test.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/controller/v2/EligibilityControllerV2Test.java
@@ -5,16 +5,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.dwp.model.v2.PersonDTOV2;
 import uk.gov.dhsc.htbhf.dwp.testhelper.v2.PersonDTOV2TestDataFactory;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.eligibility.service.v2.IdentityAndEligibilityService;
+import uk.gov.dhsc.htbhf.eligibility.testhelper.v2.CombinedIdAndEligibilityResponseTestDataFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches;
 
 @ExtendWith(MockitoExtension.class)
 class EligibilityControllerV2Test {
@@ -28,10 +28,11 @@ class EligibilityControllerV2Test {
     void shouldSuccessfullyGetIdentityAndEligibilityDecision() {
         //Given
         PersonDTOV2 person = PersonDTOV2TestDataFactory.aValidPersonDTOV2();
-        IdentityAndEligibilityResponse identityAndEligibilityResponse = anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches();
+        CombinedIdentityAndEligibilityResponse identityAndEligibilityResponse = CombinedIdAndEligibilityResponseTestDataFactory
+                .anIdMatchedEligibilityConfirmedResponseWithNoHmrcHouseholdIdentifier();
         given(service.checkIdentityAndEligibility(any())).willReturn(identityAndEligibilityResponse);
         //When
-        IdentityAndEligibilityResponse response = controller.getIdentityAndEligibilityDecision(person);
+        CombinedIdentityAndEligibilityResponse response = controller.getIdentityAndEligibilityDecision(person);
         //Then
         assertThat(response).isEqualTo(identityAndEligibilityResponse);
         verify(service).checkIdentityAndEligibility(person);

--- a/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/factory/v1/EligibilityResponseFactoryTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/factory/v1/EligibilityResponseFactoryTest.java
@@ -18,11 +18,11 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static uk.gov.dhsc.htbhf.TestConstants.DWP_HOUSEHOLD_IDENTIFIER;
+import static uk.gov.dhsc.htbhf.TestConstants.HMRC_HOUSEHOLD_IDENTIFIER;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.INELIGIBLE;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.PENDING;
-import static uk.gov.dhsc.htbhf.eligibility.testhelper.TestConstants.SIMPSON_DWP_HOUSEHOLD_IDENTIFIER;
-import static uk.gov.dhsc.htbhf.eligibility.testhelper.TestConstants.SIMPSON_HMRC_HOUSEHOLD_IDENTIFIER;
 import static uk.gov.dhsc.htbhf.eligibility.testhelper.v1.DWPEligibilityResponseTestDataFactory.aDWPEligibilityResponseWithStatus;
 import static uk.gov.dhsc.htbhf.eligibility.testhelper.v1.DWPEligibilityResponseTestDataFactory.aDwpEligibilityResponseBuilder;
 import static uk.gov.dhsc.htbhf.eligibility.testhelper.v1.DWPEligibilityResponseTestDataFactory.createChildren;
@@ -58,8 +58,8 @@ class EligibilityResponseFactoryTest {
 
         EligibilityResponse response = factory.createEligibilityResponse(dwpEligibilityResponse, hmrcEligibilityResponse);
 
-        assertThat(response.getDwpHouseholdIdentifier()).isEqualTo(SIMPSON_DWP_HOUSEHOLD_IDENTIFIER);
-        assertThat(response.getHmrcHouseholdIdentifier()).isEqualTo(SIMPSON_HMRC_HOUSEHOLD_IDENTIFIER);
+        assertThat(response.getDwpHouseholdIdentifier()).isEqualTo(DWP_HOUSEHOLD_IDENTIFIER);
+        assertThat(response.getHmrcHouseholdIdentifier()).isEqualTo(HMRC_HOUSEHOLD_IDENTIFIER);
     }
 
     @Test
@@ -70,7 +70,7 @@ class EligibilityResponseFactoryTest {
 
         EligibilityResponse response = factory.createEligibilityResponse(dwpEligibilityResponse, hmrcEligibilityResponse);
 
-        assertThat(response.getDwpHouseholdIdentifier()).isEqualTo(SIMPSON_DWP_HOUSEHOLD_IDENTIFIER);
+        assertThat(response.getDwpHouseholdIdentifier()).isEqualTo(DWP_HOUSEHOLD_IDENTIFIER);
         assertThat(response.getHmrcHouseholdIdentifier()).isNull();
     }
 
@@ -83,7 +83,7 @@ class EligibilityResponseFactoryTest {
         EligibilityResponse response = factory.createEligibilityResponse(dwpEligibilityResponse, hmrcEligibilityResponse);
 
         assertThat(response.getDwpHouseholdIdentifier()).isNull();
-        assertThat(response.getHmrcHouseholdIdentifier()).isEqualTo(SIMPSON_HMRC_HOUSEHOLD_IDENTIFIER);
+        assertThat(response.getHmrcHouseholdIdentifier()).isEqualTo(HMRC_HOUSEHOLD_IDENTIFIER);
     }
 
     @Test

--- a/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/service/v2/DWPClientV2Test.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/service/v2/DWPClientV2Test.java
@@ -28,8 +28,8 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.HttpStatus.OK;
+import static uk.gov.dhsc.htbhf.TestConstants.LISA_DATE_OF_BIRTH;
 import static uk.gov.dhsc.htbhf.dwp.testhelper.TestConstants.HOMER_NINO_V2;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.TestConstants.LISA_DOB;
 import static uk.gov.dhsc.htbhf.dwp.testhelper.TestConstants.MAGGIE_DATE_OF_BIRTH_STRING;
 import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.HttpRequestTestDataFactory.aValidEligibilityHttpEntity;
 import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches;
@@ -81,7 +81,7 @@ class DWPClientV2Test {
         //When
         IdentityAndEligibilityResponse response = dwpClient.checkIdentityAndEligibility(request);
         //Then
-        String lisaDobString = DateTimeFormatter.ISO_LOCAL_DATE.format(LISA_DOB);
+        String lisaDobString = DateTimeFormatter.ISO_LOCAL_DATE.format(LISA_DATE_OF_BIRTH);
         String syntheticIdComponents = "AA11AA[" + lisaDobString + "," + MAGGIE_DATE_OF_BIRTH_STRING + "]";
         String expectedHouseholdId = Base64.getEncoder().encodeToString(syntheticIdComponents.getBytes(UTF_8));
         assertThat(response.getHouseholdIdentifier()).isEqualTo(expectedHouseholdId);
@@ -101,10 +101,9 @@ class DWPClientV2Test {
         //Given
         DWPEligibilityRequestV2 request = DWPEligibilityRequestV2TestDataFactory.aValidDWPEligibilityRequestV2();
         IdentityAndEligibilityResponse identityAndEligibilityResponse =
-                anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches()
+                anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches(dobOfChildrenUnder4)
                         .toBuilder()
                         .householdIdentifier("")
-                        .dobOfChildrenUnder4(dobOfChildrenUnder4)
                         .build();
         given(restTemplate.exchange(anyString(), any(), any(), eq(IdentityAndEligibilityResponse.class)))
                 .willReturn(new ResponseEntity<>(identityAndEligibilityResponse, OK));

--- a/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/service/v2/IdentityAndEligibilityServiceTest.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/service/v2/IdentityAndEligibilityServiceTest.java
@@ -7,7 +7,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.dhsc.htbhf.dwp.model.v2.IdentityAndEligibilityResponse;
 import uk.gov.dhsc.htbhf.dwp.model.v2.PersonDTOV2;
+import uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory;
 import uk.gov.dhsc.htbhf.dwp.testhelper.v2.PersonDTOV2TestDataFactory;
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
+import uk.gov.dhsc.htbhf.eligibility.testhelper.v2.CombinedIdAndEligibilityResponseTestDataFactory;
 
 import java.time.LocalDate;
 
@@ -16,7 +19,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
 import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.DWPEligibilityRequestV2TestDataFactory.aValidDWPEligibilityRequestV2WithEligibilityEndDate;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.v2.IdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches;
 
 @ExtendWith(MockitoExtension.class)
 class IdentityAndEligibilityServiceTest {
@@ -36,14 +38,16 @@ class IdentityAndEligibilityServiceTest {
     void shouldSuccessfullyCheckIdentityAndEligibility() {
         //Given
         PersonDTOV2 person = PersonDTOV2TestDataFactory.aValidPersonDTOV2();
-        IdentityAndEligibilityResponse identityAndEligibilityResponse = anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches();
+        IdentityAndEligibilityResponse identityAndEligibilityResponse = IdentityAndEligibilityResponseTestDataFactory
+                .anAllMatchedEligibilityConfirmedUCResponseWithHouseholdIdentifier();
         given(client.checkIdentityAndEligibility(any())).willReturn(identityAndEligibilityResponse);
 
         //When
-        IdentityAndEligibilityResponse response = service.checkIdentityAndEligibility(person);
+        CombinedIdentityAndEligibilityResponse response = service.checkIdentityAndEligibility(person);
 
         //Then
-        assertThat(response).isEqualTo(identityAndEligibilityResponse);
+        assertThat(response).isEqualTo(CombinedIdAndEligibilityResponseTestDataFactory
+                .anIdMatchedEligibilityConfirmedResponseWithNoHmrcHouseholdIdentifier());
         verify(client).checkIdentityAndEligibility(aValidDWPEligibilityRequestV2WithEligibilityEndDate(LocalDate.now()));
     }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/testhelper/TestConstants.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/testhelper/TestConstants.java
@@ -11,6 +11,4 @@ public final class TestConstants {
     public static final LocalDate ELIGIBLE_START_DATE = LocalDate.parse("2019-02-14");
     public static final BigDecimal CTC_ANNUAL_INCOME_THRESHOLD = BigDecimal.valueOf(16190.00);
 
-    public static final String SIMPSON_DWP_HOUSEHOLD_IDENTIFIER = "dwpHousehold1";
-    public static final String SIMPSON_HMRC_HOUSEHOLD_IDENTIFIER = "hmrcHousehold1";
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/testhelper/v1/DWPEligibilityResponseTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/testhelper/v1/DWPEligibilityResponseTestDataFactory.java
@@ -9,10 +9,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.nCopies;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.TestConstants.LISA_DOB;
-import static uk.gov.dhsc.htbhf.dwp.testhelper.TestConstants.MAGGIE_DATE_OF_BIRTH;
+import static uk.gov.dhsc.htbhf.TestConstants.DWP_HOUSEHOLD_IDENTIFIER;
+import static uk.gov.dhsc.htbhf.TestConstants.LISA_DATE_OF_BIRTH;
+import static uk.gov.dhsc.htbhf.TestConstants.MAGGIE_DATE_OF_BIRTH;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
-import static uk.gov.dhsc.htbhf.eligibility.testhelper.TestConstants.SIMPSON_DWP_HOUSEHOLD_IDENTIFIER;
 
 public class DWPEligibilityResponseTestDataFactory {
 
@@ -29,12 +29,12 @@ public class DWPEligibilityResponseTestDataFactory {
     public static DWPEligibilityResponse.DWPEligibilityResponseBuilder aDwpEligibilityResponseBuilder(EligibilityStatus eligibilityStatus) {
         return DWPEligibilityResponse.builder()
                 .eligibilityStatus(eligibilityStatus)
-                .householdIdentifier(SIMPSON_DWP_HOUSEHOLD_IDENTIFIER);
+                .householdIdentifier(DWP_HOUSEHOLD_IDENTIFIER);
     }
 
     public static List<ChildDTO> createChildren(Integer numberOfChildrenUnderOne, Integer numberOfChildrenUnderFour) {
         List<ChildDTO> childrenUnderOne = nCopies(numberOfChildrenUnderOne, new ChildDTO(MAGGIE_DATE_OF_BIRTH));
-        List<ChildDTO> childrenBetweenOneAndFour = nCopies(numberOfChildrenUnderFour - numberOfChildrenUnderOne, new ChildDTO(LISA_DOB));
+        List<ChildDTO> childrenBetweenOneAndFour = nCopies(numberOfChildrenUnderFour - numberOfChildrenUnderOne, new ChildDTO(LISA_DATE_OF_BIRTH));
         return Stream.concat(childrenUnderOne.stream(), childrenBetweenOneAndFour.stream()).collect(Collectors.toList());
     }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/testhelper/v1/EligibilityResponseTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/testhelper/v1/EligibilityResponseTestDataFactory.java
@@ -3,18 +3,18 @@ package uk.gov.dhsc.htbhf.eligibility.testhelper.v1;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
 import uk.gov.dhsc.htbhf.eligibility.model.v1.EligibilityResponse;
 
+import static uk.gov.dhsc.htbhf.TestConstants.DWP_HOUSEHOLD_IDENTIFIER;
+import static uk.gov.dhsc.htbhf.TestConstants.HMRC_HOUSEHOLD_IDENTIFIER;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.NO_MATCH;
-import static uk.gov.dhsc.htbhf.eligibility.testhelper.TestConstants.SIMPSON_DWP_HOUSEHOLD_IDENTIFIER;
-import static uk.gov.dhsc.htbhf.eligibility.testhelper.TestConstants.SIMPSON_HMRC_HOUSEHOLD_IDENTIFIER;
 
 public class EligibilityResponseTestDataFactory {
 
     public static EligibilityResponse anEligibleEligibilityResponse() {
         return EligibilityResponse.builder()
                 .eligibilityStatus(ELIGIBLE)
-                .dwpHouseholdIdentifier(SIMPSON_DWP_HOUSEHOLD_IDENTIFIER)
-                .hmrcHouseholdIdentifier(SIMPSON_HMRC_HOUSEHOLD_IDENTIFIER)
+                .dwpHouseholdIdentifier(DWP_HOUSEHOLD_IDENTIFIER)
+                .hmrcHouseholdIdentifier(HMRC_HOUSEHOLD_IDENTIFIER)
                 .build();
     }
 
@@ -41,8 +41,8 @@ public class EligibilityResponseTestDataFactory {
     public static EligibilityResponse aNonMatchingEligibilityResponse() {
         return EligibilityResponse.builder()
                 .eligibilityStatus(NO_MATCH)
-                .dwpHouseholdIdentifier(SIMPSON_DWP_HOUSEHOLD_IDENTIFIER)
-                .hmrcHouseholdIdentifier(SIMPSON_HMRC_HOUSEHOLD_IDENTIFIER)
+                .dwpHouseholdIdentifier(DWP_HOUSEHOLD_IDENTIFIER)
+                .hmrcHouseholdIdentifier(HMRC_HOUSEHOLD_IDENTIFIER)
                 .build();
     }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/testhelper/v1/HMRCEligibilityResponseTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/testhelper/v1/HMRCEligibilityResponseTestDataFactory.java
@@ -3,8 +3,8 @@ package uk.gov.dhsc.htbhf.eligibility.testhelper.v1;
 import uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus;
 import uk.gov.dhsc.htbhf.eligibility.model.v1.hmrc.HMRCEligibilityResponse;
 
+import static uk.gov.dhsc.htbhf.TestConstants.HMRC_HOUSEHOLD_IDENTIFIER;
 import static uk.gov.dhsc.htbhf.eligibility.model.EligibilityStatus.ELIGIBLE;
-import static uk.gov.dhsc.htbhf.eligibility.testhelper.TestConstants.SIMPSON_HMRC_HOUSEHOLD_IDENTIFIER;
 
 public class HMRCEligibilityResponseTestDataFactory {
 
@@ -21,6 +21,6 @@ public class HMRCEligibilityResponseTestDataFactory {
     public static HMRCEligibilityResponse.HMRCEligibilityResponseBuilder anHMRCEligibilityResponseBuilder(EligibilityStatus eligibilityStatus) {
         return HMRCEligibilityResponse.builder()
                 .eligibilityStatus(eligibilityStatus)
-                .householdIdentifier(SIMPSON_HMRC_HOUSEHOLD_IDENTIFIER);
+                .householdIdentifier(HMRC_HOUSEHOLD_IDENTIFIER);
     }
 }

--- a/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/testhelper/v2/CombinedIdAndEligibilityResponseTestDataFactory.java
+++ b/api/src/test/java/uk/gov/dhsc/htbhf/eligibility/testhelper/v2/CombinedIdAndEligibilityResponseTestDataFactory.java
@@ -1,0 +1,14 @@
+package uk.gov.dhsc.htbhf.eligibility.testhelper.v2;
+
+import uk.gov.dhsc.htbhf.eligibility.model.CombinedIdentityAndEligibilityResponse;
+import uk.gov.dhsc.htbhf.eligibility.model.testhelper.CombinedIdentityAndEligibilityResponseTestDataFactory;
+
+public class CombinedIdAndEligibilityResponseTestDataFactory {
+
+    public static CombinedIdentityAndEligibilityResponse anIdMatchedEligibilityConfirmedResponseWithNoHmrcHouseholdIdentifier() {
+        return CombinedIdentityAndEligibilityResponseTestDataFactory.anIdentityMatchedEligibilityConfirmedUCResponseWithAllMatches()
+                .toBuilder()
+                .hrmcHouseholdIdentifier(null)
+                .build();
+    }
+}

--- a/swagger.yml
+++ b/swagger.yml
@@ -69,7 +69,7 @@ paths:
         "200":
           description: "OK"
           schema:
-            $ref: "#/definitions/IdentityAndEligibilityResponse"
+            $ref: "#/definitions/CombinedIdentityAndEligibilityResponse"
         "201":
           description: "Created"
         "401":
@@ -107,39 +107,7 @@ definitions:
         description: "The date of birth of the child"
     title: "ChildDTO"
     description: "A child in a household."
-  EligibilityResponse:
-    type: "object"
-    properties:
-      children:
-        type: "array"
-        items:
-          $ref: "#/definitions/ChildDTO"
-      dwpHouseholdIdentifier:
-        type: "string"
-      eligibilityStatus:
-        type: "string"
-        enum:
-        - "ELIGIBLE"
-        - "INELIGIBLE"
-        - "PENDING"
-        - "NO_MATCH"
-        - "ERROR"
-        - "DUPLICATE"
-      hmrcHouseholdIdentifier:
-        type: "string"
-      numberOfChildrenUnderFour:
-        type: "integer"
-        format: "int32"
-        example: 1
-        description: "The number of children under 4 that the person has (which will\
-          \ include the number of children under 1)"
-      numberOfChildrenUnderOne:
-        type: "integer"
-        format: "int32"
-        example: 1
-        description: "The number of children under 1 that the person has"
-    title: "EligibilityResponse"
-  IdentityAndEligibilityResponse:
+  CombinedIdentityAndEligibilityResponse:
     type: "object"
     properties:
       addressLine1Match:
@@ -163,6 +131,8 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/LocalDate"
+      dwpHouseholdIdentifier:
+        type: "string"
       eligibilityStatus:
         type: "string"
         enum:
@@ -178,7 +148,7 @@ definitions:
         - "not_supplied"
         - "invalid_format"
         - "not_set"
-      householdIdentifier:
+      hmrcHouseholdIdentifier:
         type: "string"
       identityStatus:
         type: "string"
@@ -221,7 +191,39 @@ definitions:
         - "jobseekers_allowance"
         - "pension_credit"
         - "not_set"
-    title: "IdentityAndEligibilityResponse"
+    title: "CombinedIdentityAndEligibilityResponse"
+  EligibilityResponse:
+    type: "object"
+    properties:
+      children:
+        type: "array"
+        items:
+          $ref: "#/definitions/ChildDTO"
+      dwpHouseholdIdentifier:
+        type: "string"
+      eligibilityStatus:
+        type: "string"
+        enum:
+        - "ELIGIBLE"
+        - "INELIGIBLE"
+        - "PENDING"
+        - "NO_MATCH"
+        - "ERROR"
+        - "DUPLICATE"
+      hmrcHouseholdIdentifier:
+        type: "string"
+      numberOfChildrenUnderFour:
+        type: "integer"
+        format: "int32"
+        example: 1
+        description: "The number of children under 4 that the person has (which will\
+          \ include the number of children under 1)"
+      numberOfChildrenUnderOne:
+        type: "integer"
+        format: "int32"
+        example: 1
+        description: "The number of children under 1 that the person has"
+    title: "EligibilityResponse"
   PersonDTO:
     type: "object"
     required:


### PR DESCRIPTION
… from v2 eligibility check. No call is made to HMRC API for v2 yet, this simply uses the new response object so that its available when we are ready to populate as a part of the HMRC epic. The only extra field at this time is the HMRC household identifier.

Also started using the new TestConstants from common-test where applicable.